### PR TITLE
apicurio-registry bump to version supporting JSON schema type 2.0.2.F…

### DIFF
--- a/src/values.yaml
+++ b/src/values.yaml
@@ -150,7 +150,7 @@ kafka:
 apicurio-registry:
   enabled: true
   image:
-    tag: 2.0.2.Final
+    tag: 2.2.5.Final
   kafka:
     enabled: false
 


### PR DESCRIPTION
…inal -> 2.2.5.Final