### PR TITLE
Helm improvements

### DIFF
--- a/.github/workflows/helm-test-workflow.yaml
+++ b/.github/workflows/helm-test-workflow.yaml
@@ -25,7 +25,7 @@ env:
   CHART_REPOSITORY_AUTH: "${{ secrets.CHARTS_PUBLIC_AUTH}}"
   CHARTS_PUBLIC_SNAPSHOTS_URL: "https://helm-charts.touk.pl/nexus/repository/helm-snapshots/"
   CHARTS_PUBLIC_RELEASES_URL: "https://helm-charts.touk.pl/nexus/repository/helm-releases/"
-
+  HELM_VERSION: 'version.BuildInfo{Version:"v3.13.1", GitCommit:"3547a4b5bf5edb5478ce352e18858d8a552a4110", GitTreeState:"clean", GoVersion:"go1.20.8"}'
 defaults:
   run:
     shell: bash
@@ -37,14 +37,16 @@ jobs:
     outputs:
       version: ${{ steps.setVersion.outputs.version }}
     steps:
+      - name: Verify helm version
+        run: current_helm_version=$(helm version) && echo "Current helm version $current_helm_version" && [ "$current_helm_version" = "$HELM_VERSION" ] && echo "Helm is in expected version" || echo "::warning title=Helm version is different than expected!::Helm has been updated on runner's image. It could lead to unexpected behaviour during pipeline execution!"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Print Nussknacker version
         run: |
           echo "Nussknacker version: $NUSSKNACKER_VERSION"
       - name: setVersion
         id: setVersion
-        run: echo "::set-output name=version::$(helm show chart ${{env.CHART_SRC_DIR}} | grep ^version | sed -e "s/.*:\ //;s/SNAPSHOT/SNAPSHOT.${{github.run_id}}/")"
+        run: echo "version=$(helm show chart ${{env.CHART_SRC_DIR}} | grep ^version | sed -e "s/.*:\ //;s/SNAPSHOT/SNAPSHOT.${{github.run_id}}/")" >> $GITHUB_OUTPUT
       - name: buildAll
         run: ./setup.sh
       - name: checkTemplate
@@ -52,7 +54,7 @@ jobs:
       - name: packageAll
         run: helm package ${{env.CHART_SRC_DIR}} -d dist --version "${{steps.setVersion.outputs.version}}"
       - name: Store target
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: helm-build
           path: "dist/${{env.NAME}}-${{steps.setVersion.outputs.version}}.tgz"
@@ -64,8 +66,8 @@ jobs:
       NUSSKNACKER_VERSION: staging-latest_scala-2.12
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
         with:
           name: helm-build
           path: dist
@@ -86,8 +88,8 @@ jobs:
     needs: [ build ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
         with:
           name: helm-build
           path: dist
@@ -107,8 +109,8 @@ jobs:
     needs: [ build ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
         with:
           name: helm-build
           path: dist
@@ -128,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build, test-flink, test-streaming-lite, test-request-response ]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: helm-build
           path: dist

--- a/src/Chart.lock
+++ b/src/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.2.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.59.4
+  version: 6.61.0
 - name: influxdb
   repository: https://helm.influxdata.com/
   version: 4.12.5
 - name: telegraf
   repository: https://helm.influxdata.com/
-  version: 1.8.34
-digest: sha256:a4235f4aca5b0785f910bc33cb813604cab949729753b88fb095814524fe269c
-generated: "2023-09-13T10:29:02.122496096+02:00"
+  version: 1.8.35
+digest: sha256:0f79e72af1530a708dd2b65389dd49a3808c36c750feca6faad8d6ec43ee2ed6
+generated: "2023-10-18T09:52:20.811471+02:00"

--- a/src/values.yaml
+++ b/src/values.yaml
@@ -2,6 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  kafka:
+    name: kafka
+    port: 9092
+  zookeeper: &zookeeper_ports_config
+    ports:
+      client: 2181
+  schemaRegistry:
+    name: apicurio-registry
+    path: /apis/ccompat/v6/
+
 replicaCount: 1
 
 image:
@@ -166,9 +177,7 @@ postgresql:
 
 zookeeper:
   enabled: true
-  service:
-    ports:
-      client: 2181
+  service: *zookeeper_ports_config
 
 kafka:
   enabled: true
@@ -180,7 +189,7 @@ kafka:
     enabled: false
   externalZookeeper:
     servers:
-      - "{{ .Release.Name }}-zookeeper:2181"
+      - "{{ .Release.Name }}-zookeeper:{{ .Values.global.zookeeper.ports.client }}"
 
 apicurio-registry:
   enabled: true
@@ -269,14 +278,6 @@ telegraf:
   config:
     #We suppress default influxDB configuration from chart, as we cannot easily template influxdb url
     outputs: []
-
-global:
-  kafka:
-    name: kafka
-    port: 9092
-  schemaRegistry:
-    name: apicurio-registry
-    path: /apis/ccompat/v6/
 
 nussknackerInitContainers: [ ]
 


### PR DESCRIPTION
bumped some deprecated things like:

* actions/checkout@v2 -> actions/checkout@v4
* actions/upload-artifact@v2 -> actions/upload-artifact@v3
* actions/download-artifact@v2 -> actions/download-artifact@v3
* got rid of ::set-output