### PR TITLE
1.18 fixes

### DIFF
--- a/build-deploy-verify.sh
+++ b/build-deploy-verify.sh
@@ -11,7 +11,13 @@ shift
 
 cd "$(dirname "$0")" && rm -rf dist/
 helm package -d dist/ src/
-kubectl get secret "$RELEASE-postgresql" || cat postgres-secret.yaml | POSTGRES_PASSWORD=`date +%s | sha256sum | base64 | head -c 32` RELEASE=$RELEASE MAYBE_NAMESPACE=`kubectl config view --minify -o jsonpath='{..namespace}'` NAMESPACE=${MAYBE_NAMESPACE:-default} envsubst | kubectl apply -f -
+POSTGRES_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32)
+MAYBE_NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
+NAMESPACE=${MAYBE_NAMESPACE:-default}
+kubectl get secret "$RELEASE-postgresql" || \
+ cat postgres-secret.yaml | \
+ POSTGRES_PASSWORD=$POSTGRES_PASSWORD RELEASE=$RELEASE NAMESPACE=$NAMESPACE envsubst | \
+ kubectl apply -f -
 
 helm upgrade -i "${RELEASE}" dist/*.tgz \
   --wait \

--- a/deploy-values-lite-both-processing-modes.yaml
+++ b/deploy-values-lite-both-processing-modes.yaml
@@ -1,5 +1,4 @@
 image:
-  tag: staging-latest
   pullPolicy: Always
 
 flink:

--- a/deploy-values-request-response.yaml
+++ b/deploy-values-request-response.yaml
@@ -1,5 +1,4 @@
 image:
-  tag: staging-latest
   pullPolicy: Always
 
 nussknacker:

--- a/deploy-values-streaming-lite.yaml
+++ b/deploy-values-streaming-lite.yaml
@@ -1,5 +1,4 @@
 image:
-  tag: staging-latest
   pullPolicy: Always
 
 flink:

--- a/deploy-values.yaml
+++ b/deploy-values.yaml
@@ -1,5 +1,4 @@
 image:
-  tag: staging-latest_scala-2.12
   pullPolicy: Always
 
 imagePullSecrets:
@@ -43,15 +42,3 @@ nussknacker:
 extraEnv:
   - name: NUSSKNACKER_LOG_LEVEL
     value: DEBUG
-
-telegraf:
-  enabled: true
-
-influxdb:
-  enabled: true
-
-grafana:
-  enabled: true
-
-apicurio-registry:
-  enabled: true

--- a/postgres-secret.yaml
+++ b/postgres-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: $RELEASE-postgresql
-  namespace: default
+  namespace: $NAMESPACE
   labels:
     "app.kubernetes.io/managed-by": "Helm"
   annotations:

--- a/src/README.md
+++ b/src/README.md
@@ -67,35 +67,38 @@ provided outside. The table below lists components and their roles
 Modes
 -----
 
-The `mode` configuration variable is a convenient umbrella term for the processing mode and engine. See [Glossary](https://nussknacker.io/documentation/about/GLOSSARY) for the explanation of these terms.
+The `mode` configuration variable is used to set up the engine. To read more about engines see [Documentation](https://nussknacker.io/documentation/docs/about/engines).
 
-By default, the chart runs Nussknacker in `flink` mode which deploys scenarios to Flink engine (either installed directly by the chart, or external one). It is also possible to run Nussknacker on K8s in `lite-k8s` mode. You will need to manually adjust values of the following variables if you use this `mode`:
-    ```
-    nussknacker:
-       mode: lite-k8s
-     flink:
-       enable: false
-     telegraf:
-       enabled: false  
-    ```
+By default, the chart runs Nussknacker in `flink` mode which deploys scenarios to Flink engine (either installed directly by the chart, or external one). 
+It is also possible to run Nussknacker on K8s in `lite-k8s` mode. You will need to manually adjust values of the following variables if you use this `mode`:
+```
+nussknacker:
+   mode: lite-k8s
+flink:
+  enable: false
+telegraf:
+  enabled: false  
+zookeeper:
+  enabled: false
+```
 
 In case if you want to  use only request-response processing mode in your scenarios you can also disable streaming part of the application stack:
-    ```
-    nussknacker:
-       mode: lite-k8s
-       streaming:
-         enabled: false
-     flink:
-       enable: false
-     telegraf:
-       enabled: false  
-     kafka:
-       enabled: false
-     zookeeper:
-       enabled: false
-     apicurio-registry:
-       enabled: false
-    ```
+```
+nussknacker:
+  mode: lite-k8s
+  streaming:
+    enabled: false
+flink:
+  enable: false
+telegraf:
+  enabled: false  
+kafka:
+  enabled: false
+zookeeper:
+  enabled: false
+apicurio-registry:
+  enabled: false
+```
 
 Configuration
 -------------

--- a/src/templates/_helpers.tpl
+++ b/src/templates/_helpers.tpl
@@ -179,6 +179,16 @@ nussknacker-lite-scenario
 {{- end -}}
 {{- end -}}
 
+{{- define "nussknacker.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag }}
+{{- else if or (eq .Values.nussknacker.mode "flink") (eq .Values.nussknacker.mode "flink-k8s-operator") -}}
+{{- .Chart.AppVersion }}_scala-2.12
+{{- else -}}
+{{- .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}
+
 {{- define "nussknacker.additionalClassPathModules" -}}
 {{- $additionalClassPathModules := default (list) .Values.nussknacker.additionalClassPathModules }}
 {{- if gt (len $additionalClassPathModules) 0 -}}

--- a/src/templates/_pod.tpl
+++ b/src/templates/_pod.tpl
@@ -11,7 +11,7 @@ containers:
   - name: {{ .Chart.Name }}
     securityContext:
       {{- toYaml .Values.securityContext | nindent 6 }}
-    image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+    image: "{{ .Values.image.repository }}:{{ include "nussknacker.imageTag" . }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     volumeMounts:
       - name: config

--- a/src/templates/telegraf-configmap.yaml
+++ b/src/templates/telegraf-configmap.yaml
@@ -24,10 +24,11 @@ data:
     {{ template "telegraf.nussknacker.inputs" .Values.telegraf.nussknacker.inputs }}
     {{- else }}
     [[inputs.prometheus]]
-      urls=[
-          "http://{{ include "flink.fullname" (dict "Chart" (dict "Name" "flink") "Values" .Values.flink "Release" .Release "Capabilities" .Capabilities) }}-jobmanager-headless:9999/metrics",
-          "http://{{ include "flink.fullname" (dict "Chart" (dict "Name" "flink") "Values" .Values.flink "Release" .Release "Capabilities" .Capabilities) }}-taskmanager:9999/metrics"
-      ]
+      kubernetes_label_selector = "app.kubernetes.io/name=flink"
+      monitor_kubernetes_pods = true
+      monitor_kubernetes_pods_method = "settings"
+      monitor_kubernetes_pods_namespace = "{{ template "nussknacker.namespace" . }}"
+      monitor_kubernetes_pods_port = 9999
     {{- end }}
     {{ template "telegraf.nussknacker.processors" .Values.telegraf.nussknacker.processors }}
     {{ template "telegraf.nussknacker.aggregators" .Values.telegraf.nussknacker.aggregators }}

--- a/src/values.yaml
+++ b/src/values.yaml
@@ -212,7 +212,9 @@ flink:
     monitoring:
       system:
         enabled: false
-    params: "metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory"
+    params: |+
+      metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+      metrics.reporter.prom.filterLabelValueCharacters: false
   taskmanager:
     statefulset: false
     numberOfTaskSlots: 3
@@ -265,10 +267,21 @@ influxdb:
 telegraf:
   enabled: true
   rbac:
-    create: false
+    create: true
+    clusterWide: false
+    rules:
+      - apiGroups: [""]
+        resources:
+          - nodes
+          - nodes/proxy
+          - services
+          - endpoints
+          - pods
+          - namespaces
+        verbs: ["get", "list", "watch"]
   influxdb:
-    username: ""
-    password: ""
+    username: "nussknacker"
+    password: "changeme"
   args:
     - "--config-directory"
     - "/etc/telegraf/telegraf.d"


### PR DESCRIPTION
- build-deploy-verify.sh added postgres secret always to default namespace
- authentication wasn't configured for telegraf
- telegraf had wrong input urls
- for (default) flink mode was used image tag without _scala-2.12 suffix
- was wrong indention in src/README.md